### PR TITLE
Small fix gold standard name

### DIFF
--- a/gerbil_api_wrapper/gerbil.py
+++ b/gerbil_api_wrapper/gerbil.py
@@ -99,7 +99,7 @@ class Gerbil:
 
         execute_url = self.upload_configuration_url + self.upload_data_postfix.format(
             dataset = f"{self.uploaded_dataset_prefix}_{self.gold_standard_name}({self.gold_standard_file})",
-            answerFiles = f"\"{self.anser_files_prefix}_{self.test_results_name}({self.test_results_file})(undefined)({self.dataset_reference_prefix}_{self.gold_standard_file})\"" 
+            answerFiles = f"\"{self.anser_files_prefix}_{self.test_results_name}({self.test_results_file})(undefined)({self.dataset_reference_prefix}_{self.gold_standard_name})\"" 
                 if not self.use_live_annotator else "", 
             annotator = f"\"{self.annoator}\"" if self.use_live_annotator else "",
             questionLanguage = self.language

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read_requirements():
 
 setuptools.setup(
     name="gerbil-api-wrapper",
-    version="1.0.0",
+    version="1.0.1",
     author="Paul Heinze",
     author_email="paul.heinze@student.hs-anhalt.de",
     description="A package that provides wrapper functionality for the Gerbil Benchmark Service",


### PR DESCRIPTION
Code:
```python
from gerbil_api_wrapper.gerbil import Gerbil


if __name__ == "__main__":
    wrapper = Gerbil(
        gold_standard_file="../qald-9-plus_test_gs.json",
        test_results_name="test name aaaa",
        gold_standard_name="aaaaaaa",
        test_results_file="../qald-9-plus_test_after.json",
        language="en")
    
    print(wrapper.get_results_url())
```

[Result before fix](http://gerbil-qa.aksw.org/gerbil/experiment?id=202212250000):

![image](https://user-images.githubusercontent.com/16652575/209463605-302b4b7f-6b48-4eea-9944-551a379dd32e.png)


[Result after fix](http://gerbil-qa.aksw.org/gerbil/experiment?id=202212250001):

![image](https://user-images.githubusercontent.com/16652575/209463614-f56a4292-f570-4ba4-ae42-887c30fddb4e.png)
